### PR TITLE
Review code with lot of fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [PowerShell version](https://github.com/Pacman1988/BackupAzureDevopsRepos) of 
 * Shell bash (If you're running on windows, use [WSL2](https://docs.microsoft.com/en-us/windows/wsl/) to easily run a GNU/Linux environment)
 * Azure CLI : [Installation guide](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 * Azure CLI - Devops Extension : [Installation guide](https://docs.microsoft.com/en-us/azure/devops/cli/?view=azure-devops)
-* jq, base64 packages (available in most Linux distributions)
+* git, jq, base64 packages (available in most Linux distributions)
 
 Interaction with the Azure DevOps API requires a [personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops).
 
@@ -35,19 +35,16 @@ For this backup script you'll only need to generate a PAT with read access on Co
 
 [Release notes](/docsrelease-notes.md)
 
-    ./backup-devops.sh -o DEVOPS_ORG_URL -p DEVOPS_PAT -d BACKUP_DIRECTORY --dryrun true --verbose true
-
-    Parameters:
-       -o | --organization: 
-            The azure devops organisation URL (eg: https://dev.azure.com/my-company)
-       -d | --directory: 
-            The directory where to store the backup archive.
-       -p | --pat: The Personnal Access Token (PAT) that you need to generate for your Azure Devops Account
-       -x|--dryrun: true/false - If you want to create a dummy file instead of cloning the repositories
-       -w|--projectwiki: true/false - If you want also backup the Wiki structure of the projects
-       -v|--verbose true/false - Verbose mode
-
-
+     ./backup-devops.sh [-h] -p PAT -d backup-dir -o organization -r retention [-v] [-x] [-w] -- backup Azure DevOps repositories
+     where:
+          -h  show this help text
+          -p  personal access token (PAT) for Azure DevOps [REQUIRED]
+          -d  backup directory path: the directory where to store the backup archive [REQUIRED]
+          -o  Azure DevOps organization URL (e.g. https://dev.azure.com/organization) [REQUIRED]
+          -r  retention days for backup files: how many days to keep the backup files [REQUIRED]
+          -v  verbose mode [default is false]
+          -x  dry run mode (no actual backup, only simulation) [default is false]
+          -w  backup project wiki [default is true]
 
 ## :whale: Use this in docker
 

--- a/src/backup-devops.sh
+++ b/src/backup-devops.sh
@@ -14,7 +14,7 @@ shopt -s extglob
 ################################################################################
 VERBOSE_MODE=false;
 DRY_RUN=false;
-PROJECT_WIKI=false;
+PROJECT_WIKI=true;
 
 BACKUP_SUCCESS=true;
 
@@ -44,14 +44,14 @@ function usage {
   usage="$(basename "$0") [-h] [-p pat] [-d directory] [-o organization] [-r retention] [-v] [-x] [-w] -- backup Azure DevOps repositories
 where:
     -h  show this help text
-    -p  personal access token (PAT) for Azure DevOps
-    -d  backup directory path
-    -o  organization URL (e.g. https://dev.azure.com/organization)
-    -r  retention days for backup files
-    -v  verbose mode
-    -x  dry run mode (no actual backup)
-    -w  backup project wiki"
-  printf '%s\n' "${usage}"  
+    -p  personal access token (PAT) for Azure DevOps [REQUIRED]
+    -d  backup directory path: the directory where to store the backup archive [REQUIRED]
+    -o  Azure DevOps organization URL (e.g. https://dev.azure.com/organization) [REQUIRED]
+    -r  retention days for backup files: how many days to keep the backup files [REQUIRED]
+    -v  verbose mode [default is false]
+    -x  dry run mode (no actual backup, only simulation) [default is false]
+    -w  backup project wiki [default is true]"
+  printf '%s\n' "${usage}"
 }
 
 ################################################################################

--- a/src/backup-devops.sh
+++ b/src/backup-devops.sh
@@ -142,7 +142,7 @@ az extension add --name 'azure-devops'
 echo "=== Set AZURE_DEVOPS_EXT_PAT env variable"
 export AZURE_DEVOPS_EXT_PAT=${PAT} 
 #Store PAT in Base64
-B64_PAT=$(printf "%s"":${PAT}" | base64)
+B64_PAT=$(printf "%s"":${PAT}" | base64 -w 0)
 
 echo "=== Get project list"
 ProjectList=$(az devops project list --organization ${ORGANIZATION} --query 'value[]')
@@ -154,7 +154,13 @@ if [[ "${DRY_RUN}" = true ]]; then
   echo "=== Simulate Backup folder creation [${BACKUP_DIRECTORY}]"
 else
   mkdir -p "${BACKUP_DIRECTORY}"
-  echo "=== Backup folder created [${BACKUP_DIRECTORY}]"
+  if [ $? -ne 0 ]; then
+    echo "=== Backup folder creation failed [${BACKUP_DIRECTORY}]"
+    BACKUP_SUCCESS=false
+    exit 1
+  else
+    echo "=== Backup folder created [${BACKUP_DIRECTORY}]"
+  fi
 fi
 
 #Initialize counters

--- a/src/backup-devops.sh
+++ b/src/backup-devops.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# set -o pipefail extends -e by making any failure anywhere in a pipeline fatal
-set -euo pipefail
+# strict mode configuration
+set -uo pipefail
 
 # enable extended pathname expansion (e.g. $ ls !(*.jpg|*.gif))
 shopt -s extglob

--- a/src/backup-devops.sh
+++ b/src/backup-devops.sh
@@ -258,9 +258,11 @@ if [[ "${DRY_RUN}" = true ]]; then
   exit 0
 fi
 
-#Backup summary
-#echo "=== Backup structure ==="
-#find ${BACKUP_DIRECTORY} -maxdepth 2
+if [[ "${VERBOSE_MODE}"" = true ]]; then
+  echo "=== Backup structure ==="
+  find ${BACKUP_DIRECTORY} -maxdepth 2 -ls
+fi
+
 end_time=$(date +%s)
 elapsed=$(( end_time - start_time ))
 backup_size_uncompressed=$(du -hs ${BACKUP_DIRECTORY})

--- a/src/backup-devops.sh
+++ b/src/backup-devops.sh
@@ -41,7 +41,7 @@ function die {
 
 # usage function
 function usage {
-  usage="$(basename "$0") [-h] [-p pat] [-d directory] [-o organization] [-r retention] [-v] [-x] [-w] -- backup Azure DevOps repositories
+  usage="$(basename "$0") [-h] -p PAT -d backup-dir -o organization -r retention [-v] [-x] [-w] -- backup Azure DevOps repositories
 where:
     -h  show this help text
     -p  personal access token (PAT) for Azure DevOps [REQUIRED]

--- a/src/backup-devops.sh
+++ b/src/backup-devops.sh
@@ -18,6 +18,12 @@ PROJECT_WIKI=false;
 
 BACKUP_SUCCESS=true;
 
+# required options
+PAT=""
+BACKUP_ROOT_PATH=""
+ORGANIZATION=""
+RETENTION_DAYS=""
+
 ################################################################################
 ### FUNCTIONS
 ################################################################################

--- a/src/backup-devops.sh
+++ b/src/backup-devops.sh
@@ -258,7 +258,7 @@ if [[ "${DRY_RUN}" = true ]]; then
   exit 0
 fi
 
-if [[ "${VERBOSE_MODE}"" = true ]]; then
+if [[ "${VERBOSE_MODE}" = true ]]; then
   echo "=== Backup structure ==="
   find ${BACKUP_DIRECTORY} -maxdepth 2 -ls
 fi

--- a/src/backup-devops.sh
+++ b/src/backup-devops.sh
@@ -259,7 +259,7 @@ if [[ -z "${RETENTION_DAYS}" ]]; then
 else
     if [[ "${BACKUP_SUCCESS}" = true ]]; then
         # doublecheck for BACKUP_ROOT_PATH
-        if [ -n "$(BACKUP_ROOT_PATH)" -a "$(BACKUP_ROOT_PATH)" != "/" ]; then
+        if [ -n "${BACKUP_ROOT_PATH}" -a "${BACKUP_ROOT_PATH}" != "/" ]; then
           echo "=== Apply retention policy (${RETENTION_DAYS} days)"
           find ${BACKUP_ROOT_PATH} -mindepth 1 -maxdepth 1 -type f -mtime +${RETENTION_DAYS} -delete
         else


### PR DESCRIPTION
Main fixes:
- fix possible destructive "find [..] -rm -rf" command if backup directory is empty
- fix PAT base64 wrapping (see https://github.com/lionelpere/azure-devops-repository-backup/issues/18)

Changes:
- replaced case with getops for parse options
- bash strict mode
- extend DRY_RUN to wiki

Note: this PR introduces a breaking change due to missing support in options of --style parameter (--pat is not supported anymore but only -p)