### PR TITLE
Fix DRY_RUN environment variable logic

### DIFF
--- a/src/docker-script.sh
+++ b/src/docker-script.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 RETENTION_DAYS="${RETENTION_IN_DAYS:-7}"
 
-if [[ -z "${DRY_RUN}" ]]; then
-    if [[ -z "${WIKI}" ]]; then
-    ./backup-devops.sh -p $DEVOPS_PAT -o $DEVOPS_ORG_URL -d /data -r $RETENTION_DAYS
-    else
-     echo "== INCLUDE WIKI"
-    ./backup-devops.sh -p $DEVOPS_PAT -o $DEVOPS_ORG_URL -d /data -r $RETENTION_DAYS -w
-    fi
-else
+if [[ "${DRY_RUN}" = "true" ]]; then
     echo "== DRY RUN EXECUTION"
     if [[ -z "${WIKI}" ]]; then
-    ./backup-devops.sh -p $DEVOPS_PAT -o $DEVOPS_ORG_URL -d /data -r $RETENTION_DAYS --dryrun true
+        ./backup-devops.sh -p $DEVOPS_PAT -o $DEVOPS_ORG_URL -d /data -r $RETENTION_DAYS --dryrun true
     else
-    echo "== INCLUDE WIKI"
-    ./backup-devops.sh -p $DEVOPS_PAT -o $DEVOPS_ORG_URL -d /data -r $RETENTION_DAYS --dryrun true -w
+        echo "== INCLUDE WIKI"
+        ./backup-devops.sh -p $DEVOPS_PAT -o $DEVOPS_ORG_URL -d /data -r $RETENTION_DAYS --dryrun true -w
+    fi
+else
+    if [[ -z "${WIKI}" ]]; then
+        ./backup-devops.sh -p $DEVOPS_PAT -o $DEVOPS_ORG_URL -d /data -r $RETENTION_DAYS
+    else
+        echo "== INCLUDE WIKI"
+        ./backup-devops.sh -p $DEVOPS_PAT -o $DEVOPS_ORG_URL -d /data -r $RETENTION_DAYS -w
     fi
 fi


### PR DESCRIPTION
Fixes #20

This PR resolves the issue where the DRY_RUN environment variable was not working as expected in Docker containers.

## Changes
- Fixed boolean logic in `src/docker-script.sh` to properly handle DRY_RUN values
- Now `DRY_RUN=true` enables dry-run mode, `DRY_RUN=false` runs normal mode
- Previously any non-empty value (including "false") would enable dry-run mode

## Testing
Users can now properly control dry-run behavior with:
- `DRY_RUN=true` for dry-run mode
- `DRY_RUN=false` for normal execution
- Unset DRY_RUN for normal execution (default)

Generated with [Claude Code](https://claude.ai/code)